### PR TITLE
Ajout de guillemet dans le yaml des issues pour tenter de les réparer

### DIFF
--- a/.github/ISSUE_TEMPLATE/erreur_documentation.md
+++ b/.github/ISSUE_TEMPLATE/erreur_documentation.md
@@ -1,7 +1,7 @@
 ---
-name: Signalement d'une erreur
-about: Signaler une errreur dans la documentation pour la faire corriger
-title: Erreur : <titre de l'erreur>
+name: "Signaler une erreur"
+about: "Signaler une errreur dans la documentation pour la faire corriger"
+title: "Erreur : <titre de l'erreur>"
 labels: ''
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/proposition_ajout.md
+++ b/.github/ISSUE_TEMPLATE/proposition_ajout.md
@@ -1,7 +1,7 @@
 ---
-name: Proposition
-about: Proposition d'ajout d'information à la documentation
-title: Proposition : <titre de l'erreur>
+name: "Proposition"
+about: "Proposer l'ajout d'informations à la documentation"
+title: "Proposition : <titre de l'erreur>"
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
Les templates ne sont pas pris en compte par github. Sans doute car il y a des problèmes dans le yaml sans guillemets.

Cette PR a pour vocation à corriger le problème. Sachant qu'on ne pourra vérifier la correction qu'une fois mergée…